### PR TITLE
Add docker-compose and redeploy scripts

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,30 @@
+version: '3.0'
+
+services:
+  frontend:
+    image: teodossidossev/mse2024-ui:latest
+    container_name: frontend
+    ports:
+      - "8888:8888"
+    depends_on:
+      - backend
+
+  backend:
+    image: teodossidossev/mse2024-be:latest
+    container_name: backend
+    ports:
+      - "8080:8080"
+    depends_on:
+      - mongo
+
+  mongo:
+    image: mongo:latest
+    container_name: mongo
+    ports:
+      - "27017:27017"
+    volumes:
+      - data:/data/db
+
+volumes:
+  data:
+

--- a/redeploy.sh
+++ b/redeploy.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+COMPOSE_FILE="./docker-compose.yml"
+
+declare -A services
+services["frontend"]="teodossidossev/mse2024-ui"
+services["backend"]="teodossidossev/mse2024-be"
+
+get_latest_tag() {
+    JSON=$(curl -s "https://registry.hub.docker.com/v2/repositories/$1/tags/")
+    echo $(echo "$JSON" | jq -r '.results | sort_by(.name | capture("^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$")) | last | .name')
+}
+
+ get_current_tag() {
+     TAG=$(docker-compose -f $COMPOSE_FILE config | grep "image: $1" | awk -F':' '{print $3}')
+     if [ -z "$TAG" ]; then
+         echo "No current tag found for $1 in the Docker Compose file"
+         return 1
+     fi
+     echo $TAG
+ }
+
+
+# update services if newer version
+for service in "${!services[@]}"
+do
+    REPO=${services[$service]}
+    CURRENT_TAG=$(get_current_tag $REPO)
+    if [ $? -ne 0 ]; then
+        continue
+    fi
+
+    LATEST_TAG=$(get_latest_tag $REPO)
+    if [ $? -ne 0 ]; then
+        continue
+    fi
+
+    echo "Current tag for $service: $CURRENT_TAG"
+    echo "Latest tag for $service: $LATEST_TAG"
+
+    if [ "$LATEST_TAG" != "$CURRENT_TAG" ]; then
+        echo "Newer version detected for $service. Updating to $LATEST_TAG..."
+        sed -i "s|${REPO}:${CURRENT_TAG}|${REPO}:${LATEST_TAG}|g" $COMPOSE_FILE
+        docker-compose -f $COMPOSE_FILE pull $service
+        docker-compose -f $COMPOSE_FILE up -d $service
+    else
+        echo "No updates found for $service."
+    fi
+done


### PR DESCRIPTION
This commit introduces docker-compose.yml for setting up the frontend, backend, and mongo services. Additionally, a redeploy.sh script is provided to automatically check for and update to the latest docker image tag for each service.